### PR TITLE
env testing - standalone mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,8 @@ dependencies = [
     "tqdm>=4.66.5",
     "pythermalcomfort>=2.10.0",
     "pyproj>=3.7.0",
+    "xarray>=2025.3.1",
+    "rioxarray>=0.19.0",
 ]
 
 [build-system]

--- a/tests/demos/solweig_gbg_test.py
+++ b/tests/demos/solweig_gbg_test.py
@@ -7,8 +7,9 @@ from umep import (
 )
 from umep.functions.SOLWEIGpython import Solweig_run as sr
 
+# %%
 bbox = [476070, 4203550, 477110, 4204330]
-working_folder = "temp/test2"
+working_folder = "temp/gothenburg"
 pixel_resolution = 1  # metres
 working_crs = 3007
 

--- a/umep/configsolweig.ini
+++ b/umep/configsolweig.ini
@@ -6,39 +6,39 @@
 #---------------------------------------------------------------------------------------------------------
 ####### INPUTS #######
 # output path
-output_dir=C:/temp/test/
+output_dir=temp/test/
 # working dir
-working_dir=C:/temp/test/
+working_dir=temp/test/
 # parameters json file
-para_json_path=C:/Users/xlinfr/Documents/PythonScripts/processing_umep/processor/parametersforsolweig.json
+para_json_path=umep/parametersforsolweig.json
 # Input ground and building dsm
-filepath_dsm=C:/Users/xlinfr/Documents/PythonScripts/SOLWEIG/SOLWEIGdata/DSM_KRbig.tif
+filepath_dsm=tests/data/Goteborg_SWEREF99_1200/DSM_KRbig.tif
 # Input vegetation dsm
-filepath_cdsm=C:/Users/xlinfr/Documents/PythonScripts/SOLWEIG/SOLWEIGdata/CDSM_KRbig.asc
+filepath_cdsm=tests/data/Goteborg_SWEREF99_1200/CDSM_KRbig.asc
 # Input trunkzone vegetation dsm
 filepath_tdsm=
 # Input Digital Elevation Model
 filepath_dem=
 # Input Land cover dataset
-filepath_lc=C:/Users/xlinfr/Documents/PythonScripts/SOLWEIG/SOLWEIGdata/landcover.tif
+filepath_lc=tests/data/Goteborg_SWEREF99_1200/landcover.tif
 # Input wall height raster
-filepath_wh=C:\Users\xlinfr\Desktop\SOLWEIGdata\wallheight.tif
+filepath_wh=temp/gothenburg/walls/wall_hts.tif
 # Input wall aspect raster
-filepath_wa=C:\Users\xlinfr\Desktop\SOLWEIGdata\wallaspect.tif
+filepath_wa=temp/gothenburg/walls/wall_aspects.tif
 # Skyview factor files
-input_svf=C:\Users\xlinfr\Desktop\SOLWEIGdata\svfs.zip
+input_svf=temp/gothenburg/svf/svfs.zip
 # Input file for anisotrophic sky
-input_aniso=C:\Users\xlinfr\Desktop\SOLWEIGdata\shadowmats.npz
+input_aniso=temp/gothenburg/svf/shadowmats.npz
 #Point of Interest file for ground
 poi_file=
 poi_field=
 # Input file for wall temperture scheme (Wallenberg et al. 2025)
-input_wall = C:\Users\xlinfr\Desktop\SOLWEIGdata\blabla.npz
+input_wall = '' # C:\Users\xlinfr\Desktop\SOLWEIGdata\blabla.npz
 #Point of Interest file for walls
 woi_file=
 woi_field=
 # input meteorolgical file (i.e. forcing file)
-input_met=C:\Users\xlinfr\Documents\UMEP\TutorialData\Gothenburg\Goteborg_SWEREF99_1200\gbg19970606_2015a.txt
+input_met=tests/data/Goteborg_SWEREF99_1200/gbg19970606_2015a.txt
 
 ## input settings ##
 # option to execute solweig outside of osgeo/qgis environment

--- a/umep/functions/SOLWEIGpython/Solweig_run.py
+++ b/umep/functions/SOLWEIGpython/Solweig_run.py
@@ -14,7 +14,6 @@ from ...functions.SOLWEIGpython import PET_calculations as p
 from ...functions.SOLWEIGpython import UTCI_calculations as utci
 from ...functions.SOLWEIGpython.CirclePlotBar import PolarBarPlot
 from ...functions.SOLWEIGpython.wall_surface_temperature import load_walls
-from ...functions.SOLWEIGpython.wallOfInterest import pointOfInterest
 from ...functions.SOLWEIGpython.patch_characteristics import hemispheric_image
 from ...functions.SOLWEIGpython.wallsAsNetCDF import walls_as_netcdf
 from ...functions.SOLWEIGpython.Tgmaps_v1 import Tgmaps_v1
@@ -31,11 +30,13 @@ from shutil import copyfile
 try:
     from osgeo import gdal
     from osgeo.gdalconst import *
-    from ...util.misc import saveraster, xy2latlon_fromraster
     from qgis.core import QgsRasterLayer
+    
+    from ...functions.SOLWEIGpython.wallOfInterest import pointOfInterest
+    from ...util.misc import saveraster, xy2latlon_fromraster
 except:
     pass
-from qgis.core import QgsRasterLayer
+
 # imports for standalone
 try:
     from umep import common


### PR DESCRIPTION
@biglimp 

After testing the Gothenburg test case for the new SOLWEIG, these are the changes made to get it running successfully in standalone (non-QGIS) mode in a self-contained virtual environment:

- Added the `xarray` and `rioxarray` packages to `pyproject.toml`
- Use of relative paths in `umep/configsolweig.ini` so that we don't need to use system dependent paths
- Slightly more robust path handling in `umep/common.py` (extrapolates absolute paths from relative paths).
- Minor readjustments of imports for `umep/functions/SOLWEIGpython/Solweig_run.py` to avoid `qgis` related imports for standalone mode.